### PR TITLE
Fixed back functionality

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -62,6 +62,13 @@ impl SessionCycle {
 
     fn update_curr(&mut self) {
         let session = self.sessions.front().map(String::clone);
+
+        // do nothing if front of cycle is current session
+        match (self.curr.as_ref(), session.as_ref()) {
+            (Some(curr), Some(session)) if *curr == *session => return,
+            _ => { },
+        }
+
         self.prev = self.curr.take();
         self.curr = session;
     }


### PR DESCRIPTION
Previously, when the new front of the session cycle was already the current session, the `update_curr` function would cause both the previous and current to point to the same session. This change returns early if the new front of the cycle already matches the current session.