### PR TITLE
Check zellij version compatibility on plugin load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cycle;
+mod version;
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -6,6 +7,7 @@ use zellij_tile::prelude::*;
 use serde::{Serialize, Deserialize};
 use serde_json;
 use cycle::{SessionCycle, LoadError, SaveError};
+use version::SemanticVersion;
 
 #[cfg(feature = "tracing")]
 pub fn init_tracing() {
@@ -78,8 +80,12 @@ impl ZellijPlugin for Zestty {
             PermissionType::ChangeApplicationState,
         ];
 
-        request_permission(permissions);
         show_self(true);
+
+        let version = get_zellij_version();
+        self.check_compatibility(&version);
+
+        request_permission(permissions);
         tracing::info!("requested permissions {:?}", permissions);
     }
 
@@ -134,6 +140,7 @@ impl ZellijPlugin for Zestty {
 }
 
 impl Zestty {
+    const MINIMUM_SUPPORTED_VERSION: SemanticVersion = SemanticVersion::new(0, 40, 0);
     const SESSIONS_FILE: &'static str = "/tmp/zestty_sessions.json";
 
     #[tracing::instrument(skip_all)]
@@ -283,6 +290,18 @@ impl Zestty {
                 tracing::error!("could not create sessions file: {}", io_err),
             Err(SaveError::CouldNotSerialize(se_err)) =>
                 tracing::error!("could not serialize sessions: {}", se_err),
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn check_compatibility(&mut self, version: &str) {
+        tracing::debug!("zellij version: {}", version);
+
+        match SemanticVersion::try_from(version) {
+            Ok(version) => if version < Self::MINIMUM_SUPPORTED_VERSION {
+                panic!("Minimum zellij version not met!");
+            },
+            Err(_) => panic!("Could not parse zellij version!")
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use zellij_tile::prelude::*;
 use serde::{Serialize, Deserialize};
 use serde_json;
 use cycle::{SessionCycle, LoadError, SaveError};
-use version::SemanticVersion;
+use version::{CompatibilityInfo, SemanticVersion};
 
 #[cfg(feature = "tracing")]
 pub fn init_tracing() {
@@ -33,6 +33,7 @@ pub fn init_tracing() {
 
 #[derive(Default)]
 struct Zestty {
+    compat_info: CompatibilityInfo,
     buffered_events: Vec<Event>,
     buffered_command: Option<Command>,
     permission_granted: Option<bool>,
@@ -67,6 +68,17 @@ impl ZellijPlugin for Zestty {
         init_tracing();
         tracing::debug!("tracing initialized");
 
+        self.set_compatibility();
+
+        // show plugin pane on load
+        show_self(true);
+
+        // do not subscribe to events or request permissions if not compatible
+        if !self.compat_info.compatible() {
+            tracing::error!("versions are incompatible");
+            return;
+        }
+
         let events = &[
             EventType::PermissionRequestResult,
             EventType::SessionUpdate,
@@ -79,11 +91,6 @@ impl ZellijPlugin for Zestty {
             PermissionType::ReadApplicationState,
             PermissionType::ChangeApplicationState,
         ];
-
-        show_self(true);
-
-        let version = get_zellij_version();
-        self.check_compatibility(&version);
 
         request_permission(permissions);
         tracing::info!("requested permissions {:?}", permissions);
@@ -136,11 +143,36 @@ impl ZellijPlugin for Zestty {
     }
 
     #[tracing::instrument(skip_all)]
-    fn render(&mut self, _rows: usize, _cols: usize) { }
+    fn render(&mut self, _rows: usize, _cols: usize) {
+        // do not render if versions are compatible
+        if self.compat_info.compatible() {
+            tracing::info!("rendering compatibility info");
+            return;
+        }
+
+        let min_version = format!("{}   ", self.compat_info.min_version);
+
+        let (help_text, actual_version) = match &self.compat_info.actual_version {
+            Some(version) =>
+                ("Minimum zellij version not met!", format!("{}", version)),
+            None =>
+                ("Could not parse zellij version!", String::default()),
+        };
+
+        print_text(Text::new(help_text).color_all(1));
+
+        let table = Table::new()
+            .add_row(vec!["Minimum Version   ", "Actual Version"])
+            .add_styled_row(vec![
+                Text::new(min_version).color_all(0),
+                Text::new(actual_version).color_all(0)
+            ]);
+
+        print_table_with_coordinates(table, 0, 2, None, None);
+    }
 }
 
 impl Zestty {
-    const MINIMUM_SUPPORTED_VERSION: SemanticVersion = SemanticVersion::new(0, 40, 0);
     const SESSIONS_FILE: &'static str = "/tmp/zestty_sessions.json";
 
     #[tracing::instrument(skip_all)]
@@ -294,15 +326,13 @@ impl Zestty {
     }
 
     #[tracing::instrument(skip_all)]
-    fn check_compatibility(&mut self, version: &str) {
+    fn set_compatibility(&mut self) {
+        let version = get_zellij_version();
+        let version = version.as_str();
         tracing::debug!("zellij version: {}", version);
 
-        match SemanticVersion::try_from(version) {
-            Ok(version) => if version < Self::MINIMUM_SUPPORTED_VERSION {
-                panic!("Minimum zellij version not met!");
-            },
-            Err(_) => panic!("Could not parse zellij version!")
-        }
+        let version = SemanticVersion::try_from(version).ok();
+        self.compat_info = CompatibilityInfo::new(version);
     }
 
     fn find_session(&self) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,11 +150,11 @@ impl ZellijPlugin for Zestty {
             return;
         }
 
-        let min_version = format!("{}   ", self.compat_info.min_version);
+        let min_version = self.compat_info.min_version.to_string();
 
         let (help_text, actual_version) = match &self.compat_info.actual_version {
             Some(version) =>
-                ("Minimum zellij version not met!", format!("{}", version)),
+                ("Minimum zellij version not met!", version.to_string()),
             None =>
                 ("Could not parse zellij version!", String::default()),
         };

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,30 @@
 use std::num::ParseIntError;
 use std::cmp::Ordering;
+use std::fmt::{self, Display};
 
-#[derive(PartialEq, Eq)]
+#[derive(Default)]
+pub struct CompatibilityInfo {
+    pub min_version: SemanticVersion,
+    pub actual_version: Option<SemanticVersion>,
+}
+
+impl CompatibilityInfo {
+    pub const fn new(version: Option<SemanticVersion>) -> Self {
+        Self {
+            min_version: SemanticVersion::new(0, 40, 0),
+            actual_version: version,
+        }
+    }
+
+    pub fn compatible(&self) -> bool {
+        match &self.actual_version {
+            Some(version) if *version >= self.min_version => true,
+            _ => false
+        }
+    }
+}
+
+#[derive(Default, PartialEq, Eq)]
 pub struct SemanticVersion {
     major: usize,
     minor: usize,
@@ -34,6 +57,12 @@ impl<'a> TryFrom<&'a str> for SemanticVersion
             }),
             _ => Err(SemanticVersionError)
         }
+    }
+}
+
+impl Display for SemanticVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,61 @@
+use std::num::ParseIntError;
+use std::cmp::Ordering;
+
+#[derive(PartialEq, Eq)]
+pub struct SemanticVersion {
+    major: usize,
+    minor: usize,
+    patch: usize,
+}
+
+impl SemanticVersion {
+    pub const fn new(major: usize, minor: usize, patch: usize) -> Self {
+        Self { major, minor, patch }
+    }
+}
+
+pub struct SemanticVersionError;
+
+impl From<ParseIntError> for SemanticVersionError {
+    fn from(_value: ParseIntError) -> Self { Self }
+}
+
+impl<'a> TryFrom<&'a str> for SemanticVersion
+{
+    type Error = SemanticVersionError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        let mut versions = value.split(".");
+        match (versions.next(), versions.next(), versions.next()) {
+            (Some(major), Some(minor), Some(patch)) => Ok(SemanticVersion {
+                major: major.parse()?,
+                minor: minor.parse()?,
+                patch: patch.parse()?,
+            }),
+            _ => Err(SemanticVersionError)
+        }
+    }
+}
+
+impl PartialOrd for SemanticVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SemanticVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // compare major versions
+        if self.major > other.major { return Ordering::Greater; }
+        if self.major < other.major { return Ordering::Less; }
+
+        // compare minor versions
+        if self.minor > other.minor { return Ordering::Greater; }
+        if self.minor < other.minor { return Ordering::Less; }
+
+        // compare patch versions
+        if self.minor > other.minor { Ordering::Greater }
+        else if self.minor < other.minor { Ordering::Less }
+        else { Ordering::Equal }
+    }
+}


### PR DESCRIPTION
Checks the compatibility of the zestty plugin with the user's version of zellij on load. Since zestty relies on certain functions and events from the plugin API, the plugin cannot operate with zellij if it is below a minimum required version. If incompatible, zestty will display the minimum required zellij version compared to the user's installed version. It will not subscribe to any events or request permissions, so it will also not process any piped commands.