### PR TITLE
Default layout configuration

### DIFF
--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -5,10 +5,16 @@ Communication with the zestty plugin is done via JSON-formatted payloads in pipe
 Send messages to the plugin using the `zellij pipe` command:
 
 ```sh
-zellij pipe --plugin "https://github.com/aidantlynch00/zestty/releases/latest/download/zestty.wasm" -- <payload>
+zellij pipe \
+    --plugin "https://github.com/aidantlynch00/zestty/releases/latest/download/zestty.wasm" \
+    --plugin-configuration "default_layout=<layout>" \
+    -- "<payload>"
 ```
 
+Use the `default_layout=<layout>` configuration to change the layout the zestty plugin defaults when no layout is provided to the `switch-session` command. 
+
 ## Available Commands
+The following are the different JSON payloads that can be sent to the zestty plugin.
 
 ### Switch Session
 Creates or switches to a session by name with an optional working directory and zellij layout.
@@ -30,7 +36,7 @@ Records the current session in the navigation history.
 ```
 
 > [!IMPORTANT]
-> The `switch-session` command handles adding the requested session to the session cycle. This is what zestty uses when _inside_ of a zellij session. The `add-session-to-cycle` command is used by zestty when creating or attaching from _outside_ of a zellij session to keep the session cycle up-to-date.
+> The `switch-session` command handles adding the requested session to the session cycle. This is what the zestty script uses when _inside_ of a zellij session. The `add-session-to-cycle` command is used by the zestty script when creating or attaching from _outside_ of a zellij session to keep the session cycle up-to-date.
 
 ### Cycle Previous
 Switch to the previous session in the cycle history.
@@ -54,7 +60,7 @@ Switch back to the last attached session.
 ```
 
 ## Cycle Data
-The plugin maintains the session cycle in `/tmp/zestty_sessions.json`. When switching sessions:
+The plugin maintains the session cycle in `/tmp/zellij-XXXX/zestty_sessions.json`. When switching sessions:
 
 1. Dead sessions are automatically removed from the cycle
 2. The target session is added to the cycle

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -11,7 +11,7 @@ zellij pipe \
     -- "<payload>"
 ```
 
-Use the `default_layout=<layout>` configuration to change the layout the zestty plugin defaults when no layout is provided to the `switch-session` command. Can be a bare name, an absolute file path, or a URL.
+Use the `default_layout=<layout>` configuration to change the layout the zestty plugin defaults when no layout is provided to the `switch-session` command. Can be the bare name of a layout in your layouts directory, an absolute file path, or a URL.
 
 ## Available Commands
 The following are the different JSON payloads that can be sent to the zestty plugin.

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -11,7 +11,7 @@ zellij pipe \
     -- "<payload>"
 ```
 
-Use the `default_layout=<layout>` configuration to change the layout the zestty plugin defaults when no layout is provided to the `switch-session` command. 
+Use the `default_layout=<layout>` configuration to change the layout the zestty plugin defaults when no layout is provided to the `switch-session` command. Can be a bare name, an absolute file path, or a URL.
 
 ## Available Commands
 The following are the different JSON payloads that can be sent to the zestty plugin.
@@ -26,7 +26,8 @@ Creates or switches to a session by name with an optional working directory and 
 **Parameters:**
 - `name` (required): Session name to switch to or create
 - `path` (optional): Working directory for the session
-- `layout` (optional): Layout file to use, defaults to "default"
+- `layout` (optional): Layout to use, defaults to "default"
+    - can be a bare name, an absolute file path, or a URL
 
 ### Add Session to Cycle
 Records the current session in the navigation history.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This file is sourced at runtime to configure zestty. All of the following values
 zestty cannot detect the default layout set in your zellij configuration.
 
 - `ZESTTY_DEFAULT_LAYOUT`: changes the layout zestty defaults to if no layout is specified (default "default")
-    - can be a bare name, a file path, or a URL
+    - can be a bare name, an absolute file path, or a URL
 
 ## Installation
 A minimal installation of zestty only requires you to download the [zestty script](https://github.com/aidantlynch00/zestty/releases/latest/download/zestty). Since zellij can download plugins over HTTP and cache them, by default zestty uses the latest release of the plugin hosted on GitHub. A prebuilt plugin binary or an archive of both the script and plugin binary can be downloaded on the [releases page](https://github.com/aidantlynch00/zestty/releases/latest).

--- a/README.md
+++ b/README.md
@@ -100,16 +100,22 @@ zestty looks in the following locations for a configuration file:
 This file is sourced at runtime to configure zestty. All of the following values are also configurable via environment variable, which take precendence over the configuration file.
 
 #### Delimiters
-- `ZESTTY_DELIM`: single character, changes the delimiter zestty uses when listing and sessionizing sessions (default ':').
-- `ZESTTY_PROJECT_DELIM`: single character, changes the delimiter zestty uses to split lines in the projects file (default ':').
+- `ZESTTY_DELIM`: single character, changes the delimiter zestty uses when listing and sessionizing sessions (default ":").
+- `ZESTTY_PROJECT_DELIM`: single character, changes the delimiter zestty uses to split lines in the projects file (default ":").
 
 #### Plugin URL
 - `ZESTTY_PLUGIN_URL`: changes the plugin location zestty uses when communicating with the zestty plugin.
     - follows the zellij convention for plugin URLs
-    - defaults to 'https://github.com/aidantlynch00/zestty/releases/latest/download/zestty.wasm'
+    - defaults to "https://github.com/aidantlynch00/zestty/releases/latest/download/zestty.wasm"
 
 > [!TIP]
 > Download the zestty plugin and change `ZESTTY_PLUGIN_URL` to point to your local copy!
+
+#### Default Layout
+zestty cannot detect the default layout set in your zellij configuration.
+
+- `ZESTTY_DEFAULT_LAYOUT`: changes the layout zestty defaults to if no layout is specified (default "default")
+    - can be a bare name, a file path, or a URL
 
 ## Installation
 A minimal installation of zestty only requires you to download the [zestty script](https://github.com/aidantlynch00/zestty/releases/latest/download/zestty). Since zellij can download plugins over HTTP and cache them, by default zestty uses the latest release of the plugin hosted on GitHub. A prebuilt plugin binary or an archive of both the script and plugin binary can be downloaded on the [releases page](https://github.com/aidantlynch00/zestty/releases/latest).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/f255e42e-13f6-4d1d-8c1d-e2f4909ef1b5
 
 ## Requirements
 - [zellij](https://zellij.dev/) >= v0.40.0
-    - A default zellij layout named "default" in your layouts directory (see [limitations](#limitations))
+    - A default zellij layout as a fallback (see configuration [here](#default-layout))
 - `git` for worktree and submodule lists
 - [fzf](https://github.com/junegunn/fzf) >= v0.65.0 (optional, enables session picking)
 - Common utilities: `awk`, `basename`, `cat`, `cut`, `grep`, `head`, `printf`, `realpath`, `sed`, `sleep`, `xargs`
@@ -112,10 +112,11 @@ This file is sourced at runtime to configure zestty. All of the following values
 > Download the zestty plugin and change `ZESTTY_PLUGIN_URL` to point to your local copy!
 
 #### Default Layout
-zestty cannot detect the default layout set in your zellij configuration.
+zestty cannot detect the default layout set in your zellij configuration. Set a default layout to use as a fallback when a layout is not specified.
 
 - `ZESTTY_DEFAULT_LAYOUT`: changes the layout zestty defaults to if no layout is specified (default "default")
-    - can be a bare name, an absolute file path, or a URL
+    - can be the bare name of a layout in your layouts directory, an absolute file path, or a URL
+    - see [zellij documentation](https://zellij.dev/documentation/layouts.html) for more info
 
 ## Installation
 A minimal installation of zestty only requires you to download the [zestty script](https://github.com/aidantlynch00/zestty/releases/latest/download/zestty). Since zellij can download plugins over HTTP and cache them, by default zestty uses the latest release of the plugin hosted on GitHub. A prebuilt plugin binary or an archive of both the script and plugin binary can be downloaded on the [releases page](https://github.com/aidantlynch00/zestty/releases/latest).
@@ -181,7 +182,6 @@ The zestty script pipes messages to the zestty plugin to enable certain features
 
 ## Limitations
 - zestty does not pass flags through to zellij. If you would like to change the configuration file location or configuration directory, prefer the `ZELLIJ_CONFIG_FILE` and `ZELLIJ_CONFIG_DIR` environment variables.
-- zestty cannot determine the user's configured default layout and falls back to the layout file named "default" when a layout is not provided. Ensure that you have a layout named "default" in your layouts directory.
 
 ## AI Use
 AI use was kept to a minimum on this project. zestty was written "the old-fashioned way", with a few minor edits attributable to AI. Maybe this is obvious given that this project is not 50k lines long. Anything that makes its way to the main branch will have been reviewed by myself, always.

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,9 +341,12 @@ impl Zestty {
     #[tracing::instrument(skip_all)]
     fn determine_layout(&self, layout: Option<String>) -> LayoutInfo {
         // use or_else's to avoid unnecessary allocations
-        layout.map(to_layout_info)
+        let layout = layout.map(to_layout_info)
             .or_else(|| self.default_layout.clone())
-            .unwrap_or_else(|| LayoutInfo::File(String::from("default")))
+            .unwrap_or_else(|| LayoutInfo::File(String::from("default")));
+
+        tracing::debug!("determined layout: {:?}", layout);
+        return layout;
     }
 
     fn find_session(&self) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ struct Zestty {
     buffered_command: Option<Command>,
     permission_granted: Option<bool>,
     sessions: Option<Vec<SessionInfo>>,
+    default_layout: Option<String>,
     cycle: SessionCycle,
 }
 
@@ -63,7 +64,7 @@ enum Command {
 
 impl ZellijPlugin for Zestty {
     #[tracing::instrument(skip_all)]
-    fn load(&mut self, _configuration: BTreeMap<String, String>) {
+    fn load(&mut self, mut configuration: BTreeMap<String, String>) {
         #[cfg(feature = "tracing")]
         init_tracing();
         tracing::debug!("tracing initialized");
@@ -94,6 +95,9 @@ impl ZellijPlugin for Zestty {
 
         request_permission(permissions);
         tracing::info!("requested permissions {:?}", permissions);
+
+        // take from map to avoid allocation
+        self.default_layout = configuration.remove("default_layout");
     }
 
     #[tracing::instrument(skip_all)]
@@ -231,9 +235,14 @@ impl Zestty {
         let SwitchSessionArgs { name, path, layout } = args;
 
         let cwd = path.map(PathBuf::from);
+        let default_layout = self.default_layout
+            .as_deref()
+            .unwrap_or("default")
+            .to_string();
+
         let layout = match layout {
             Some(layout) => LayoutInfo::File(layout),
-            None => LayoutInfo::File(String::from("default"))
+            None => LayoutInfo::File(default_layout)
         };
 
         // add the session to the cycle

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct Zestty {
     buffered_command: Option<Command>,
     permission_granted: Option<bool>,
     sessions: Option<Vec<SessionInfo>>,
-    default_layout: Option<String>,
+    default_layout: Option<LayoutInfo>,
     cycle: SessionCycle,
 }
 
@@ -97,7 +97,9 @@ impl ZellijPlugin for Zestty {
         tracing::info!("requested permissions {:?}", permissions);
 
         // take from map to avoid allocation
-        self.default_layout = configuration.remove("default_layout");
+        self.default_layout = configuration
+            .remove("default_layout")
+            .map(to_layout_info);
     }
 
     #[tracing::instrument(skip_all)]
@@ -235,15 +237,7 @@ impl Zestty {
         let SwitchSessionArgs { name, path, layout } = args;
 
         let cwd = path.map(PathBuf::from);
-        let default_layout = self.default_layout
-            .as_deref()
-            .unwrap_or("default")
-            .to_string();
-
-        let layout = match layout {
-            Some(layout) => LayoutInfo::File(layout),
-            None => LayoutInfo::File(default_layout)
-        };
+        let layout = self.determine_layout(layout);
 
         // add the session to the cycle
         self.cycle.push(name.clone());
@@ -344,6 +338,14 @@ impl Zestty {
         self.compat_info = CompatibilityInfo::new(version);
     }
 
+    #[tracing::instrument(skip_all)]
+    fn determine_layout(&self, layout: Option<String>) -> LayoutInfo {
+        // use or_else's to avoid unnecessary allocations
+        layout.map(to_layout_info)
+            .or_else(|| self.default_layout.clone())
+            .unwrap_or_else(|| LayoutInfo::File(String::from("default")))
+    }
+
     fn find_session(&self) -> Option<String> {
         for session in self.sessions.as_ref()? {
             if session.is_current_session {
@@ -352,5 +354,20 @@ impl Zestty {
         }
 
         None
+    }
+}
+
+fn to_layout_info(layout: String) -> LayoutInfo {
+    if let Some(builtin) = layout.strip_prefix("zellij:") {
+        LayoutInfo::BuiltIn(builtin.to_string())
+    }
+    else if layout.starts_with("http:") || layout.starts_with("https:") {
+        LayoutInfo::Url(layout)
+    }
+    else {
+        match layout.strip_prefix("file:") {
+            Some(file) => LayoutInfo::File(file.to_string()),
+            None => LayoutInfo::File(layout),
+        }
     }
 }

--- a/zestty
+++ b/zestty
@@ -59,7 +59,7 @@ usage: zestty create <name> [path] [layout]
 $(bold "Parameters")
 name        name of the session
 path        working directory for the session, defaults to current directory
-layout      name of the layout to use, default layout if not provided
+layout      name of the layout to use, configured default layout if not provided
 EOF
 }
 
@@ -163,6 +163,22 @@ zestty_get_session_state() {
     fi
 }
 
+zestty_call_plugin() {
+    _cp_payload=${1-}
+    _cp_session=${2-"$ZELLIJ_SESSION_NAME"}
+
+    if [ -n "$_cp_session" ]; then
+        _cp_session_opt="--session $_cp_session"
+    else
+        _cp_session_opt=""
+    fi
+
+    command zellij $_cp_session_opt pipe \
+        --plugin "$ZESTTY_PLUGIN_URL" \
+        --plugin-configuration "default_layout=$ZESTTY_DEFAULT_LAYOUT" \
+        -- "$_cp_payload"
+}
+
 # Create a backgrounded subshell to call out to the zestty plugin to add the
 # session to the history cycle once we are inside our target session.
 zestty_call_add_session_to_cycle() {
@@ -172,9 +188,7 @@ zestty_call_add_session_to_cycle() {
     (
         {
             sleep 1
-            exec zellij --session "$_ca_name" \
-                pipe --plugin "$ZESTTY_PLUGIN_URL" -- \
-                "{ \"command\": \"add-session-to-cycle\" }"
+            zestty_call_plugin "{ \"command\": \"add-session-to-cycle\" }" "$_ca_name"
         } > /dev/null 2>&1 &
     )
 }
@@ -198,7 +212,7 @@ zestty_call_switch_session() {
     fi
 
     _cs_options="$_cs_options }"
-    exec zellij pipe --plugin "$ZESTTY_PLUGIN_URL" -- "$_cs_options"
+    zestty_call_plugin "$_cs_options"
 }
 
 zestty_match_project_name() {
@@ -257,7 +271,7 @@ zestty_create() {
     _c_cwd=$ZESTTY_CWD
     _c_name="$1"
     _c_path=${2:-"$_c_cwd"}
-    _c_layout=${3:-"default"}
+    _c_layout=${3:-}
 
     case "$_c_name" in
         "-?" | "-h" | "--help")
@@ -296,7 +310,9 @@ zestty_create() {
                 --session "$_c_name" \
                 --new-session-with-layout "$_c_layout"
         else
-            exec zellij --session "$_c_name"
+            exec zellij \
+                --session "$_c_name" \
+                --new-session-with-layout "$ZESTTY_DEFAULT_LAYOUT"
         fi
 
         cd "$_c_cwd"
@@ -735,17 +751,17 @@ zestty_sessionize() {
 
 zestty_previous() {
     [ "$ZELLIJ" = 1 ] && exit_fail "Must be in a zellij session!"
-    exec zellij pipe --plugin "$ZESTTY_PLUGIN_URL" -- "{ \"command\": \"cycle-previous\" }"
+    zestty_call_plugin "{ \"command\": \"cycle-previous\" }"
 }
 
 zestty_next() {
     [ "$ZELLIJ" = 1 ] && exit_fail "Must be in a zellij session!"
-    exec zellij pipe --plugin "$ZESTTY_PLUGIN_URL" -- "{ \"command\": \"cycle-next\" }"
+    zestty_call_plugin "{ \"command\": \"cycle-next\" }"
 }
 
 zestty_back() {
     [ "$ZELLIJ" = 1 ] && exit_fail "Must be in a zellij session!"
-    exec zellij pipe --plugin "$ZESTTY_PLUGIN_URL" -- "{ \"command\": \"cycle-back\" }"
+    zestty_call_plugin "{ \"command\": \"cycle-back\" }"
 }
 
 # Do not proceed if config is invalid
@@ -768,6 +784,7 @@ ZELLIJ=${ZELLIJ:-1}
 ZESTTY_DELIM_ENV=${ZESTTY_DELIM:-}
 ZESTTY_PROJECT_DELIM_ENV=${ZESTTY_PROJECT_DELIM:-}
 ZESTTY_PLUGIN_URL_ENV=${ZESTTY_PLUGIN_URL:-}
+ZESTTY_DEFAULT_LAYOUT_ENV=${ZESTTY_DEFAULT_LAYOUT:-}
 
 _z_config_file=$(zestty_find_config_file)
 if [ -n "$_z_config_file" ]; then
@@ -778,19 +795,13 @@ fi
 ZESTTY_DELIM=${ZESTTY_DELIM:-":"}
 ZESTTY_PROJECT_DELIM=${ZESTTY_PROJECT_DELIM:-":"}
 ZESTTY_PLUGIN_URL=${ZESTTY_PLUGIN_URL:-"https://github.com/aidantlynch00/zestty/releases/latest/download/zestty.wasm"}
+ZESTTY_DEFAULT_LAYOUT=${ZESTTY_DEFAULT_LAYOUT:-"default"}
 
 # Prefer values from environment
-if [ -n "$ZESTTY_DELIM_ENV" ]; then
-    ZESTTY_DELIM=$ZESTTY_DELIM_ENV
-fi
-
-if [ -n "$ZESTTY_PROJECT_DELIM_ENV" ]; then
-    ZESTTY_PROJECT_DELIM=$ZESTTY_PROJECT_DELIM_ENV
-fi
-
-if [ -n "$ZESTTY_PLUGIN_URL_ENV" ]; then
-    ZESTTY_PLUGIN_URL=$ZESTTY_PLUGIN_URL_ENV
-fi
+[ -n "$ZESTTY_DELIM_ENV" ] && ZESTTY_DELIM=$ZESTTY_DELIM_ENV
+[ -n "$ZESTTY_PROJECT_DELIM_ENV" ] && ZESTTY_PROJECT_DELIM=$ZESTTY_PROJECT_DELIM_ENV
+[ -n "$ZESTTY_PLUGIN_URL_ENV" ] && ZESTTY_PLUGIN_URL=$ZESTTY_PLUGIN_URL_ENV
+[ -n "$ZESTTY_DEFAULT_LAYOUT_ENV" ] && ZESTTY_DEFAULT_LAYOUT=$ZESTTY_DEFAULT_LAYOUT_ENV
 
 case "$_z_command" in
     "-?" | "-h" | "--help" | "h" | "help") zestty_usage;;

--- a/zestty
+++ b/zestty
@@ -123,6 +123,7 @@ zestty_config() {
 $(bold "ZESTTY_DELIM")            "$ZESTTY_DELIM"
 $(bold "ZESTTY_PROJECT_DELIM")    "$ZESTTY_PROJECT_DELIM"
 $(bold "ZESTTY_PLUGIN_URL")       "$ZESTTY_PLUGIN_URL"
+$(bold "ZESTTY_DEFAULT_LAYOUT")   "$ZESTTY_DEFAULT_LAYOUT"
 EOF
 }
 


### PR DESCRIPTION
Adds a configuration item to the zestty script and the zestty plugin to control the fallback layout when one is not specified. The default value is "default", so without configuration zestty operates the same as it did before. This addresses a small gap where users may have a default layout configured other than "default".