### PR TITLE
Check for layout in path

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -13,9 +13,11 @@
 
 | Function | Inputs | Outputs | Description |
 |----------|--------|---------|-------------|
+| `zestty_canonicalize_path` | Path | Canonicalized path | Replaces a leading `~` with `$HOME` and canonicalizes the path. |
 | `zestty_find_file_in_order` | File paths | First existing readable file path | Searches for files in order and returns the first readable one. |
 | `zestty_find_config_file` | N/A | Config file path or empty | Finds zestty configuration file if it exists. |
 | `zestty_find_project_file` | N/A | Projects file path or empty | Finds zestty projects file if it exists. |
+| `zestty_resolve_layout` | `1`: path<br>`2`: layout (optional) | Local layout path or passed layout | If layout is a bare name, outputs `"$path/$layout.zellij.kdl` if the file exists. If no layout, outputs `$path/layout.zellij.kdl` if the file exists. Otherwise, outputs the layout unchanged. |
 | `zestty_function_exists` | `1`: function name | Exit code 0 if it exists, 1 otherwise | Checks if a function with the given name is defined in the current shell environment. |
 | `zestty_get_session_state` | `1`: session name | One of `active`, `dead`, or `dne` (does not exist) | Checks if a zellij session exists and returns its state. |
 | `zestty_call_switch_session` | `1`: name<br>`2`: path (optional)<br>`3`: layout (optional) | N/A | Pipes message to plugin to switch/create session inside an existing zellij session. |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A POSIX-compliant shell script and accompanying zellij plugin for quickly moving
 - `zestty create <name> [path] [layout]`: create a new session (works within a session)
 
 #### Smart Layouts
-- If the layout is a bare name, zestty first looks for a `[layout].zellij.kdl` layout file under the path. Otherwise, the layout is used as passed.
+- If the layout is a bare name, zestty first looks for a `[layout].zellij.kdl` layout file under the path. If the file exists it is used, otherwise the layout is unchanged.
 - If no layout is specified, zestty looks for a `layout.zellij.kdl` file under the path before falling back to the configured default layout.
 
 ### Attach

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ A POSIX-compliant shell script and accompanying zellij plugin for quickly moving
 > [!NOTE]
 > Use `zestty help` to see the full help text. Run each command with no arguments to print its help text.
 
-### Create and Attach
+### Create
 - `zestty create <name> [path] [layout]`: create a new session (works within a session)
+
+#### Smart Layouts
+- If the layout is a bare name, zestty first looks for a `[layout].zellij.kdl` layout file under the path. Otherwise, the layout is used as passed.
+- If no layout is specified, zestty looks for a `layout.zellij.kdl` file under the path before falling back to the configured default layout.
+
+### Attach
 - `zestty attach <name>`: attach to an existing session (works within a session)
 
 ### Picking Sessions
@@ -88,11 +94,14 @@ zestty is project-centric and employs a few tricks to make sessionizing feel sma
 ## Configuration
 
 ### Projects
-zestty does not scan your filesystem to find projects. Instead, you are expected to maintain a list of your projects, their locations, and optionally a zellij layout to apply when creating the session. Each line should be in the following format `name:path:layout` (example: `zestty:~/projects/zestty:edit-and-git`).
+zestty does not scan your filesystem to find projects. Instead, you are expected to maintain a list of your projects, their locations, and optionally a layout to apply when creating the session. Each line should be in the following format `name:path:layout` (example: `zestty:~/projects/zestty:edit-and-git`).
 
 zestty looks in the following locations for a projects file:
 1. ~/.config/zestty/projects
 2. /etc/zestty/projects
+
+> [!TIP]
+> Use [smart layouts](#smart-layouts) to keep your project layouts under the root of the project.
 
 ### Config File
 zestty looks in the following locations for a configuration file:

--- a/zestty
+++ b/zestty
@@ -660,10 +660,10 @@ zestty_sessionize_project() {
 
     _sp_state=$(zestty_get_session_state "$_sp_name")
     case "$_sp_state" in
-        "dne") zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout";;
+        "dne") zestty_create "$_sp_name" "$_sp_path" "$_sp_layout";;
         "dead")
             zellij delete-session "$_sp_name" > /dev/null
-            zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout"
+            zestty_create "$_sp_name" "$_sp_path" "$_sp_layout"
             ;;
         "active") zestty_attach "$_sp_name";;
     esac

--- a/zestty
+++ b/zestty
@@ -263,6 +263,30 @@ zestty_match_project_path() {
     done < "$_mpp_project_file"
 }
 
+zestty_resolve_layout() {
+    _rl_path=${1:-}
+    _rl_layout=${2:-}
+
+    if [ -n "$_rl_layout" ]; then
+        # check if layout is bare name
+        if echo "$_rl_layout" | grep -qv "\.kdl$"; then
+            _rl_layout_path="$_rl_path/$_rl_layout.zellij.kdl"
+            if [ -f "$_rl_layout_path" ]; then
+                echo "$_rl_layout_path"
+                return
+            fi
+        fi
+    else
+        _rl_layout_path="$_rl_path/layout.zellij.kdl"
+        if [ -f "$_rl_layout_path" ]; then
+            echo "$_rl_layout_path"
+            return
+        fi
+    fi
+
+    echo "$_rl_layout"
+}
+
 zestty_function_exists() {
     type -- "$1" 2> /dev/null | grep -q "function"
 }
@@ -633,14 +657,17 @@ zestty_sessionize_project() {
     fi
 
     _sp_state=$(zestty_get_session_state "$_sp_name")
-    case "$_sp_state" in
-        "dne") zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout";;
-        "dead")
-            zellij delete-session "$_sp_name" > /dev/null
-            zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout"
-            ;;
-        "active") zestty_attach "$_sp_name";;
-    esac
+    if [ "$_sp_state" = "active" ]; then
+        zestty_attach "$_sp_name"
+        return
+    fi
+
+    if [ "$_sp_state" = "dead" ]; then
+        zellij delete-session "$_sp_name" > /dev/null
+    fi
+
+    _sp_layout=$(zestty_resolve_layout "$_sp_path" "$_sp_layout")
+    zestty_create "$_sp_name" "$_sp_path" "$_sp_layout"
 }
 
 zestty_sessionize_worktree() {

--- a/zestty
+++ b/zestty
@@ -298,9 +298,8 @@ zestty_create() {
             zestty_create_usage
     fi
 
-    _c_cwd=$ZESTTY_CWD
     _c_name="$1"
-    _c_path=${2:-"$_c_cwd"}
+    _c_path=${2:-"$ZESTTY_CWD"}
     _c_layout=${3:-}
 
     case "$_c_name" in
@@ -316,10 +315,9 @@ zestty_create() {
             zestty_attach_usage
     fi
 
+    _c_path=$(zestty_canonicalize_path "$_c_path")
     if ! [ -d "$_c_path" ]; then
         exit_fail "'$_c_path' is not a directory!"
-    else
-        _c_path=$(realpath "$_c_path")
     fi
 
     _c_layout=$(zestty_resolve_layout "$_c_path" "$_c_layout")
@@ -347,7 +345,7 @@ zestty_create() {
                 --new-session-with-layout "$ZESTTY_DEFAULT_LAYOUT"
         fi
 
-        cd "$_c_cwd"
+        cd "$ZESTTY_CWD"
     fi
 }
 
@@ -651,11 +649,6 @@ zestty_sessionize_project() {
         exit_fail "Project name required!"
     elif [ -z "$_sp_path" ]; then
         exit_fail "Project path required!"
-    fi
-
-    _sp_path=$(zestty_canonicalize_path "$_sp_path")
-    if ! [ -d "$_sp_path" ]; then
-        exit_fail "Project path must be a directory!"
     fi
 
     _sp_state=$(zestty_get_session_state "$_sp_name")

--- a/zestty
+++ b/zestty
@@ -713,7 +713,6 @@ zestty_sessionize_worktree() {
 zestty_sessionize_submodule() {
     _su_name=${1:-}
     _su_path=${2:-}
-    _su_layout=""
 
     if [ -z "$_su_name" ]; then
         exit_fail "Submodule name required!"
@@ -741,7 +740,7 @@ zestty_sessionize_submodule() {
 
     _su_state=$(zestty_get_session_state "$_su_name")
     case "$_su_state" in
-        "dne") zestty_create "$_su_name" "$_su_path" "$_su_layout";;
+        "dne") zestty_create "$_su_name" "$_su_path";;
         "dead" | "active") zestty_attach "$_su_name";;
     esac
 }

--- a/zestty
+++ b/zestty
@@ -127,6 +127,14 @@ $(bold "ZESTTY_DEFAULT_LAYOUT")   "$ZESTTY_DEFAULT_LAYOUT"
 EOF
 }
 
+zestty_canonicalize_path() {
+    _cp_path=${1:-}
+    [ -z "$_cp_path" ] && return
+
+    _cp_path=$(echo "$_cp_path" | sed "s|^~|$HOME|")
+    realpath --canonicalize-missing "$_cp_path"
+}
+
 zestty_find_file_in_order() {
     for _ffio_file in "$@"; do
         if [ -f "$_ffio_file" ] && [ -r "$_ffio_file" ]; then
@@ -235,21 +243,18 @@ zestty_match_project_name() {
 }
 
 zestty_match_project_path() {
-    _mpp_expected_relpath=${1:-}
-    [ -z "$_mpp_expected_relpath" ] && return
-
-    _mpp_expected_relpath=$(echo "$_mpp_expected_relpath" | sed "s|^~|$HOME|")
-    _mpp_expected_abspath=$(realpath "$_mpp_expected_relpath")
+    _mpp_expected_path=${1:-}
+    [ -z "$_mpp_expected_path" ] && return
 
     _mpp_project_file=$(zestty_find_project_file)
     [ -z "$_mpp_project_file" ] && return
 
+    _mpp_expected_path=$(zestty_canonicalize_path "$_mpp_expected_path")
     while read -r _mpp_project; do
-        _mpp_actual_relpath=$(echo "$_mpp_project" | cut -d "$ZESTTY_PROJECT_DELIM" -f "2")
-        _mpp_actual_relpath=$(echo "$_mpp_actual_relpath" | sed "s|^~|$HOME|")
-        _mpp_actual_abspath=$(realpath "$_mpp_actual_relpath")
+        _mpp_actual_path=$(echo "$_mpp_project" | cut -d "$ZESTTY_PROJECT_DELIM" -f "2")
+        _mpp_actual_path=$(zestty_canonicalize_path "$_mpp_actual_path")
 
-        if [ "$_mpp_expected_abspath" = "$_mpp_actual_abspath" ]; then
+        if [ "$_mpp_expected_path" = "$_mpp_actual_path" ]; then
             echo "$_mpp_project" |
             sed -e "s/$ZESTTY_PROJECT_DELIM/$ZESTTY_DELIM/g" \
                 -e "s/^/project$ZESTTY_DELIM/"
@@ -622,9 +627,8 @@ zestty_sessionize_project() {
         exit_fail "Project path required!"
     fi
 
-    _sp_abspath=$(echo "$_sp_path" | sed "s|^~|$HOME|")
-    _sp_abspath=$(realpath "$_sp_abspath")
-    if ! [ -d "$_sp_abspath" ]; then
+    _sp_path=$(zestty_canonicalize_path "$_sp_path")
+    if ! [ -d "$_sp_path" ]; then
         exit_fail "Project path must be a directory!"
     fi
 

--- a/zestty
+++ b/zestty
@@ -322,6 +322,8 @@ zestty_create() {
         _c_path=$(realpath "$_c_path")
     fi
 
+    _c_layout=$(zestty_resolve_layout "$_c_path" "$_c_layout")
+
     if [ "$ZELLIJ" = "0" ]; then
         zestty_call_switch_session \
             "$_c_name" \
@@ -657,17 +659,14 @@ zestty_sessionize_project() {
     fi
 
     _sp_state=$(zestty_get_session_state "$_sp_name")
-    if [ "$_sp_state" = "active" ]; then
-        zestty_attach "$_sp_name"
-        return
-    fi
-
-    if [ "$_sp_state" = "dead" ]; then
-        zellij delete-session "$_sp_name" > /dev/null
-    fi
-
-    _sp_layout=$(zestty_resolve_layout "$_sp_path" "$_sp_layout")
-    zestty_create "$_sp_name" "$_sp_path" "$_sp_layout"
+    case "$_sp_state" in
+        "dne") zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout";;
+        "dead")
+            zellij delete-session "$_sp_name" > /dev/null
+            zestty_create "$_sp_name" "$_sp_abspath" "$_sp_layout"
+            ;;
+        "active") zestty_attach "$_sp_name";;
+    esac
 }
 
 zestty_sessionize_worktree() {


### PR DESCRIPTION
If a bare layout name is passed upon creation, check for a file named [name].zellij.kdl in the creation path. Similarly, if no layout is passed, check for a layout.zellij.kdl file in the creation path. If neither of these cases apply, use the layout as it was passed. This allows projects to be configured with global layouts (in the zellij config's layouts folder) or with local layouts under the project root. This was already possible if the layout file was configured as an absolute path but this change removes the need to do so to have a project-local layout.